### PR TITLE
fix: 视频下载链 403 时回退到播放 URL 兜底下载

### DIFF
--- a/internal/app/spider.go
+++ b/internal/app/spider.go
@@ -28,8 +28,10 @@ import (
 	"time"
 
 	iurl "net/url"
+	nhttp "net/http"
 
 	"github.com/fatih/color"
+	ihttp "github.com/qinjintian/qq-zone/internal/net/http"
 	"github.com/qinjintian/qq-zone/internal/pkg/util"
 	"github.com/qinjintian/qq-zone/internal/qzone"
 	"github.com/tidwall/gjson"
@@ -81,6 +83,13 @@ type Spider struct {
 	logger    *zap.SugaredLogger
 
 	results DownloadResult
+}
+
+type mediaTask struct {
+	candidates []qzone.VideoCandidate
+	videoID    string
+	filename   string
+	isVideo    bool
 }
 
 // NewSpider 实例化一个下载爬虫。
@@ -389,12 +398,6 @@ func (s *Spider) downloadItem(ctx context.Context, p *mpb.Progress, targetUin st
 		filenameDate = "00000000000000"
 	}
 
-	type mediaTask struct {
-		url      string
-		filename string
-		isVideo  bool
-	}
-
 	var tasks []mediaTask
 	isVideo := photo.Get("is_video").Bool()
 
@@ -423,16 +426,24 @@ func (s *Spider) downloadItem(ctx context.Context, p *mpb.Progress, targetUin st
 	imgFilename += ext
 
 	if isVideo {
-		videoURL, videoErr := s.client.GetVideoDownloadURL(ctx, targetUin, album.Get("id").String(), sloc)
-		if videoErr == nil && videoURL != "" {
-			vidFilename := fmt.Sprintf("VID_%s_%s_%s.mp4", filenameDate[:8], filenameDate[8:], util.MD5(sloc)[8:24])
-			tasks = append(tasks, mediaTask{url: videoURL, filename: vidFilename, isVideo: true})
-		} else {
+		source, videoErr := s.client.GetVideoSource(ctx, targetUin, album.Get("id").String(), sloc, photo)
+		if videoErr != nil || source == nil || len(source.Candidates) == 0 {
 			s.results.addFailedItem(s.makeFailedItem(targetUin, album, photo, sloc, videoErr, true))
 			return nil
 		}
+		vidFilename := fmt.Sprintf("VID_%s_%s_%s.mp4", filenameDate[:8], filenameDate[8:], util.MD5(sloc)[8:24])
+		tasks = append(tasks, mediaTask{
+			candidates: source.Candidates,
+			videoID:    source.VideoID,
+			filename:   vidFilename,
+			isVideo:    true,
+		})
 	} else {
-		tasks = append(tasks, mediaTask{url: imgSource, filename: imgFilename, isVideo: false})
+		tasks = append(tasks, mediaTask{
+			candidates: []qzone.VideoCandidate{{URL: imgSource, Kind: "image"}},
+			filename:   imgFilename,
+			isVideo:    false,
+		})
 	}
 
 	for _, task := range tasks {
@@ -441,13 +452,8 @@ func (s *Spider) downloadItem(ctx context.Context, p *mpb.Progress, targetUin st
 			base := strings.TrimSuffix(task.filename, filepath.Ext(task.filename))
 			if existingPath, ok := localFiles[base]; ok {
 				task.filename = filepath.Base(existingPath)
-				head, headErr := s.client.Http.Head(ctx, task.url, map[string]string{"cookie": s.client.Cookie})
-				if headErr == nil {
-					cLen, _ := strconv.ParseInt(head.Get("Content-Length"), 10, 64)
-					fi, _ := os.Stat(existingPath)
-					if cLen > 0 && fi != nil && cLen <= fi.Size() {
-						isSkip = true
-					}
+				if s.shouldSkipExisting(ctx, existingPath, task.candidates) {
+					isSkip = true
 				}
 			}
 		}
@@ -460,61 +466,7 @@ func (s *Spider) downloadItem(ctx context.Context, p *mpb.Progress, targetUin st
 			}
 
 			target := filepath.Join(savePath, task.filename)
-			headers := map[string]string{
-				"cookie":     s.client.Cookie,
-				"user-agent": "Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36",
-			}
-
-			if task.isVideo {
-				headers["Referer"] = fmt.Sprintf("https://user.qzone.qq.com/%s/infocenter", targetUin)
-				headers["Accept"] = "*/*"
-				headers["Accept-Encoding"] = "identity;q=1, *;q=0"
-				headers["Connection"] = "keep-alive"
-				headers["Sec-Fetch-Dest"] = "video"
-				headers["Sec-Fetch-Mode"] = "no-cors"
-				headers["Sec-Fetch-Site"] = "cross-site"
-				headers["Range"] = "bytes=0-"
-
-				if u, parseErr := iurl.Parse(task.url); parseErr == nil {
-					headers["Host"] = u.Host
-				}
-			}
-
-			downloadRetry := 3
-			if task.isVideo {
-				downloadRetry = 8
-			}
-
-			res, downloadErr := s.client.Http.Download(
-				ctx,
-				task.url,
-				target,
-				headers,
-				downloadRetry,
-				600,
-				p,
-				task.filename,
-				originalName,
-				s.trackWrittenBytes,
-			)
-
-			if downloadErr != nil && task.isVideo {
-				if strings.Contains(downloadErr.Error(), "404") && strings.Contains(task.url, ".f0.mp4") {
-					originalURL := strings.Replace(task.url, ".f0.mp4", ".f20.mp4", 1)
-					res, downloadErr = s.client.Http.Download(
-						ctx,
-						originalURL,
-						target,
-						headers,
-						downloadRetry,
-						600,
-						p,
-						task.filename,
-						originalName,
-						s.trackWrittenBytes,
-					)
-				}
-			}
+			res, downloadErr := s.downloadMedia(ctx, p, targetUin, task, target, originalName)
 
 			if downloadErr != nil {
 				s.results.addFailedItem(s.makeFailedItem(targetUin, album, photo, task.filename, fmt.Errorf("download failed: %w", downloadErr), task.isVideo))
@@ -571,6 +523,163 @@ func (s *Spider) downloadItem(ctx context.Context, p *mpb.Progress, targetUin st
 	}
 
 	return nil
+}
+
+func (s *Spider) shouldSkipExisting(ctx context.Context, existingPath string, candidates []qzone.VideoCandidate) bool {
+	fi, err := os.Stat(existingPath)
+	if err != nil || fi.Size() <= 0 {
+		return false
+	}
+	for _, cand := range candidates {
+		if cand.Kind == qzone.VideoSourceGetInfo || ihttp.IsHLSURL(cand.URL) {
+			continue
+		}
+		head, headErr := s.client.Http.Head(ctx, cand.URL, map[string]string{"cookie": s.client.Cookie})
+		if headErr != nil {
+			continue
+		}
+		cLen, _ := strconv.ParseInt(head.Get("Content-Length"), 10, 64)
+		if cLen > 0 && cLen <= fi.Size() {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *Spider) downloadMedia(ctx context.Context, p *mpb.Progress, targetUin string, task mediaTask, target, originalName string) (map[string]interface{}, error) {
+	candidates := append([]qzone.VideoCandidate(nil), task.candidates...)
+	var (
+		res     map[string]interface{}
+		lastErr error
+		tried   []string
+		triedID bool
+	)
+
+	for i := 0; i < len(candidates); i++ {
+		cand := candidates[i]
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+
+		if cand.Kind == qzone.VideoSourceGetInfo {
+			continue
+		}
+
+		kind := cand.Kind
+		if kind == "" {
+			kind = "unknown"
+		}
+		res, lastErr = s.downloadCandidate(ctx, p, targetUin, cand, target, task.filename, originalName, task.isVideo)
+		if lastErr == nil {
+			if kind != qzone.VideoSourceDownload && task.isVideo {
+				s.logger.Debugf("video fallback succeeded via %s for %s", kind, originalName)
+			}
+			return res, nil
+		}
+
+		tried = append(tried, fmt.Sprintf("%s: %v", kind, lastErr))
+		s.logger.Debugf("video source %s failed for %s: %v", kind, originalName, lastErr)
+
+		if task.isVideo && !triedID && task.videoID != "" && ihttp.IsDeadURL(lastErr) && i == len(candidates)-1 {
+			triedID = true
+			extra := s.client.ResolveTencentVideo(ctx, task.videoID)
+			candidates = append(candidates, extra...)
+		}
+	}
+
+	if task.isVideo && !triedID && task.videoID != "" {
+		for _, extra := range s.client.ResolveTencentVideo(ctx, task.videoID) {
+			res, lastErr = s.downloadCandidate(ctx, p, targetUin, extra, target, task.filename, originalName, true)
+			if lastErr == nil {
+				s.logger.Debugf("video fallback succeeded via getinfo for %s", originalName)
+				return res, nil
+			}
+			tried = append(tried, fmt.Sprintf("%s: %v", extra.Kind, lastErr))
+		}
+	}
+
+	if lastErr == nil {
+		return nil, fmt.Errorf("no downloadable url")
+	}
+	if len(tried) <= 1 {
+		return nil, lastErr
+	}
+	return nil, fmt.Errorf("all %d sources failed; last: %w; tried: %s", len(tried), lastErr, strings.Join(tried, " | "))
+}
+
+func (s *Spider) downloadCandidate(ctx context.Context, p *mpb.Progress, targetUin string, cand qzone.VideoCandidate, target, filename, originalName string, isVideo bool) (map[string]interface{}, error) {
+	headers := s.buildDownloadHeaders(targetUin, cand.URL, isVideo)
+	res, err := s.doDownload(ctx, p, cand, target, filename, originalName, headers, isVideo)
+	if err != nil && isVideo && ihttp.IsDeadURL(err) && headers["cookie"] != "" {
+		// 部分播放 CDN 不接受跨域 Cookie，去掉后再试一次，更接近浏览器播放请求。
+		anon := cloneHeaders(headers)
+		delete(anon, "cookie")
+		res, err = s.doDownload(ctx, p, cand, target, filename, originalName, anon, isVideo)
+	}
+	return res, err
+}
+
+func (s *Spider) doDownload(ctx context.Context, p *mpb.Progress, cand qzone.VideoCandidate, target, filename, originalName string, headers map[string]string, isVideo bool) (map[string]interface{}, error) {
+	if cand.Kind == qzone.VideoSourceHLS || ihttp.IsHLSURL(cand.URL) {
+		return s.client.Http.DownloadHLS(ctx, cand.URL, target, headers, p, filename, originalName, s.trackWrittenBytes)
+	}
+
+	retry := 3
+	opts := []ihttp.DownloadOption{}
+	if isVideo {
+		retry = 2
+		opts = append(opts, ihttp.WithFatalStatuses(
+			nhttp.StatusForbidden,
+			nhttp.StatusNotFound,
+			nhttp.StatusGone,
+		))
+	}
+
+	return s.client.Http.Download(
+		ctx,
+		cand.URL,
+		target,
+		headers,
+		retry,
+		600,
+		p,
+		filename,
+		originalName,
+		s.trackWrittenBytes,
+		opts...,
+	)
+}
+
+func (s *Spider) buildDownloadHeaders(targetUin, rawURL string, isVideo bool) map[string]string {
+	headers := map[string]string{
+		"cookie":     s.client.Cookie,
+		"user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+	}
+	if !isVideo {
+		return headers
+	}
+	headers["Referer"] = fmt.Sprintf("https://user.qzone.qq.com/%s/infocenter", targetUin)
+	headers["Accept"] = "*/*"
+	headers["Accept-Encoding"] = "identity;q=1, *;q=0"
+	headers["Connection"] = "keep-alive"
+	headers["Sec-Fetch-Dest"] = "video"
+	headers["Sec-Fetch-Mode"] = "no-cors"
+	headers["Sec-Fetch-Site"] = "cross-site"
+	headers["Range"] = "bytes=0-"
+	if u, parseErr := iurl.Parse(rawURL); parseErr == nil {
+		headers["Host"] = u.Host
+	}
+	return headers
+}
+
+func cloneHeaders(src map[string]string) map[string]string {
+	dst := make(map[string]string, len(src))
+	for k, v := range src {
+		dst[k] = v
+	}
+	return dst
 }
 
 func (s *Spider) buildAlbumPath(targetUin string, albumName string) string {

--- a/internal/net/http/hls.go
+++ b/internal/net/http/hls.go
@@ -1,0 +1,296 @@
+/*
+ * Copyright (c) 2026 qinjintian. All rights reserved.
+ *
+ * No Part of this file may be reproduced, stored
+ * in a retrieval system, or transmitted, in any form, or by any means,
+ * electronic, mechanical, photocopying, recording, or otherwise,
+ * without the prior consent of qinjintian.
+ *
+ * @Author: qinjintian<514092640@qq.com>
+ * @Date: 2026-09-01
+ * @LastEditors: qinjintian<514092640@qq.com>
+ * @LastEditTime: 2026-09-01 15:40:00
+ * @FileName: hls.go
+ * @Description: [HLS/m3u8 播放链兜底下载，用于 download_url 失效时按网页播放器同样的分片方式拉取视频]
+ */
+
+package http
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/qinjintian/qq-zone/internal/pkg/util"
+	"github.com/vbauerster/mpb/v8"
+	"github.com/vbauerster/mpb/v8/decor"
+)
+
+type hlsVariant struct {
+	url       string
+	bandwidth int
+}
+
+// IsHLSURL 判断 URL 是否为 HLS 播放列表。
+func IsHLSURL(raw string) bool {
+	u := strings.ToLower(raw)
+	return strings.Contains(u, ".m3u8") || strings.Contains(u, "m3u8?")
+}
+
+// DownloadHLS 下载 m3u8 播放列表及其分片，并按顺序拼接为本地文件。
+// 若远端实际返回的不是播放列表（例如仍是 mp4），则回退到普通 Download。
+func (c *Client) DownloadHLS(ctx context.Context, playlistURL, target string, headers map[string]string, p *mpb.Progress, name, originalName string, onProgress func(int64)) (map[string]interface{}, error) {
+	return c.downloadHLS(ctx, playlistURL, target, headers, p, name, originalName, onProgress, 0)
+}
+
+func (c *Client) downloadHLS(ctx context.Context, playlistURL, target string, headers map[string]string, p *mpb.Progress, name, originalName string, onProgress func(int64), depth int) (map[string]interface{}, error) {
+	if depth > 3 {
+		return nil, fmt.Errorf("hls playlist nested too deep")
+	}
+	body, status, respHeader, err := c.getUnthrottled(ctx, playlistURL, headers)
+	if err != nil {
+		return nil, err
+	}
+	if status != http.StatusOK && status != http.StatusPartialContent {
+		return nil, &StatusError{Code: status, Status: http.StatusText(status)}
+	}
+
+	trimmed := strings.TrimSpace(string(body))
+	if !strings.HasPrefix(trimmed, "#EXTM3U") {
+		contentType := ""
+		if respHeader != nil {
+			contentType = respHeader.Get("Content-Type")
+		}
+		if !strings.Contains(strings.ToLower(contentType), "mpegurl") {
+			return c.Download(ctx, playlistURL, target, headers, 2, 600, p, name, originalName, onProgress, WithFatalStatuses(http.StatusForbidden, http.StatusNotFound, http.StatusGone))
+		}
+		return nil, fmt.Errorf("invalid m3u8 playlist")
+	}
+
+	base, err := url.Parse(playlistURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid playlist url: %w", err)
+	}
+
+	variants, segments, initURI := parseM3U8(trimmed, base)
+	if len(variants) > 0 {
+		best := variants[0]
+		for _, v := range variants[1:] {
+			if v.bandwidth > best.bandwidth {
+				best = v
+			}
+		}
+		return c.downloadHLS(ctx, best.url, target, headers, p, name, originalName, onProgress, depth+1)
+	}
+	if len(segments) == 0 {
+		return nil, fmt.Errorf("m3u8 playlist has no segments")
+	}
+
+	targetDir := filepath.Dir(target)
+	if !util.IsDir(targetDir) {
+		if mkdirErr := os.MkdirAll(targetDir, os.ModePerm); mkdirErr != nil {
+			return nil, fmt.Errorf("failed to create target directory: %w", mkdirErr)
+		}
+	}
+
+	out, err := os.Create(target)
+	if err != nil {
+		return nil, err
+	}
+	defer out.Close()
+
+	parts := make([]string, 0, len(segments)+1)
+	if initURI != "" {
+		parts = append(parts, initURI)
+	}
+	parts = append(parts, segments...)
+
+	var (
+		bar       *mpb.Bar
+		lastSpeed string
+		copied    int64
+	)
+	startTime := time.Now()
+	if p != nil {
+		bar = p.AddBar(int64(len(parts)),
+			mpb.BarRemoveOnComplete(),
+			mpb.PrependDecorators(
+				decor.Name(fmt.Sprintf("原文件: %s -> 保存为: %s", originalName, name), decor.WC{W: 55, C: decor.DindentRight}),
+				decor.Name("  HLS "),
+				decor.CountersNoUnit("%d / %d"),
+			),
+			mpb.AppendDecorators(
+				decor.Name(" | 速度: "),
+				decor.Any(func(st decor.Statistics) string {
+					if st.Completed && lastSpeed != "" {
+						return lastSpeed
+					}
+					elapsed := time.Since(startTime)
+					if elapsed < 100*time.Millisecond || copied <= 0 {
+						return "0 B/s"
+					}
+					speed := float64(copied) / elapsed.Seconds()
+					lastSpeed = util.FormatBytes(int64(speed)) + "/s"
+					return lastSpeed
+				}, decor.WC{W: 15, C: decor.DindentRight}),
+			),
+		)
+	}
+
+	for _, partURL := range parts {
+		select {
+		case <-ctx.Done():
+			if bar != nil {
+				bar.Abort(true)
+			}
+			return nil, ctx.Err()
+		default:
+		}
+
+		segBody, segStatus, _, segErr := c.getUnthrottled(ctx, partURL, headers)
+		if segErr != nil {
+			if bar != nil {
+				bar.Abort(true)
+			}
+			return nil, fmt.Errorf("hls segment download failed: %w", segErr)
+		}
+		if segStatus != http.StatusOK && segStatus != http.StatusPartialContent {
+			if bar != nil {
+				bar.Abort(true)
+			}
+			return nil, &StatusError{Code: segStatus, Status: http.StatusText(segStatus)}
+		}
+		n, writeErr := out.Write(segBody)
+		if writeErr != nil {
+			if bar != nil {
+				bar.Abort(true)
+			}
+			return nil, writeErr
+		}
+		copied += int64(n)
+		if onProgress != nil && n > 0 {
+			onProgress(int64(n))
+		}
+		if bar != nil {
+			bar.Increment()
+		}
+	}
+
+	if bar != nil {
+		bar.SetTotal(-1, true)
+	}
+
+	return map[string]interface{}{
+		"filename": filepath.Base(target),
+		"dir":      targetDir,
+		"path":     target,
+	}, nil
+}
+
+func (c *Client) getUnthrottled(ctx context.Context, rawURL string, headers map[string]string) ([]byte, int, http.Header, error) {
+	resp, err := c.resty.R().
+		SetContext(ctx).
+		SetHeaders(headers).
+		Get(rawURL)
+	if err != nil {
+		return nil, 0, nil, err
+	}
+	return resp.Body(), resp.StatusCode(), resp.Header(), nil
+}
+
+func parseM3U8(body string, base *url.URL) ([]hlsVariant, []string, string) {
+	var (
+		variants  []hlsVariant
+		segments  []string
+		initURI   string
+		bandwidth int
+		isMaster  bool
+	)
+
+	scanner := bufio.NewScanner(strings.NewReader(body))
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "#EXT-X-STREAM-INF") {
+			isMaster = true
+			bandwidth = parseM3U8AttrInt(line, "BANDWIDTH")
+			continue
+		}
+		if strings.HasPrefix(line, "#EXT-X-MAP:") {
+			if uri := parseM3U8QuotedURI(line); uri != "" {
+				initURI = resolvePlaylistURL(base, uri)
+			}
+			continue
+		}
+		if strings.HasPrefix(line, "#") {
+			continue
+		}
+		abs := resolvePlaylistURL(base, line)
+		if abs == "" {
+			continue
+		}
+		if isMaster {
+			variants = append(variants, hlsVariant{url: abs, bandwidth: bandwidth})
+			bandwidth = 0
+			continue
+		}
+		segments = append(segments, abs)
+	}
+	return variants, segments, initURI
+}
+
+func parseM3U8AttrInt(line, key string) int {
+	upper := strings.ToUpper(line)
+	idx := strings.Index(upper, key+"=")
+	if idx < 0 {
+		return 0
+	}
+	rest := line[idx+len(key)+1:]
+	end := strings.IndexAny(rest, ",\r\n")
+	if end >= 0 {
+		rest = rest[:end]
+	}
+	n, _ := strconv.Atoi(strings.TrimSpace(rest))
+	return n
+}
+
+func parseM3U8QuotedURI(line string) string {
+	idx := strings.Index(strings.ToUpper(line), "URI=")
+	if idx < 0 {
+		return ""
+	}
+	rest := strings.TrimSpace(line[idx+4:])
+	if strings.HasPrefix(rest, "\"") {
+		rest = rest[1:]
+		if end := strings.Index(rest, "\""); end >= 0 {
+			return rest[:end]
+		}
+	}
+	end := strings.IndexAny(rest, ",\r\n")
+	if end >= 0 {
+		rest = rest[:end]
+	}
+	return strings.Trim(rest, "\"")
+}
+
+func resolvePlaylistURL(base *url.URL, ref string) string {
+	ref = strings.TrimSpace(ref)
+	if ref == "" || base == nil {
+		return ref
+	}
+	u, err := url.Parse(ref)
+	if err != nil {
+		return ref
+	}
+	return base.ResolveReference(u).String()
+}

--- a/internal/net/http/http.go
+++ b/internal/net/http/http.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -54,6 +55,76 @@ type resumeMetadata struct {
 type progressReader struct {
 	reader     io.Reader
 	onProgress func(int64)
+}
+
+// StatusError 表示远端以明确 HTTP 状态码拒绝了这次下载。
+type StatusError struct {
+	Code   int
+	Status string
+}
+
+func (e *StatusError) Error() string {
+	if e == nil {
+		return "download failed with status: unknown"
+	}
+	return fmt.Sprintf("download failed with status: %s", e.Status)
+}
+
+// HTTPStatus 从错误中提取 HTTP 状态码；无法识别时返回 0。
+func HTTPStatus(err error) int {
+	var se *StatusError
+	if errors.As(err, &se) && se != nil {
+		return se.Code
+	}
+	return 0
+}
+
+// IsDeadURL 判断该错误是否表示“这条 URL 本身不可用”，应立即换源而不是当作风控重试。
+func IsDeadURL(err error) bool {
+	switch HTTPStatus(err) {
+	case http.StatusForbidden, http.StatusNotFound, http.StatusGone, http.StatusUnavailableForLegalReasons:
+		return true
+	default:
+		if err == nil {
+			return false
+		}
+		msg := err.Error()
+		return strings.Contains(msg, "403") ||
+			strings.Contains(msg, "404") ||
+			strings.Contains(msg, "410") ||
+			strings.Contains(msg, "Forbidden") ||
+			strings.Contains(msg, "Not Found")
+	}
+}
+
+type downloadOptions struct {
+	fatalStatuses map[int]bool
+}
+
+// DownloadOption 用于微调单次下载行为。
+type DownloadOption func(*downloadOptions)
+
+// WithFatalStatuses 指定遇到这些状态码时立即失败、不再退避重试。
+// 视频多源兜底会把 403/404 视为当前 URL 失效，从而立刻切换到播放链。
+func WithFatalStatuses(codes ...int) DownloadOption {
+	return func(o *downloadOptions) {
+		if o.fatalStatuses == nil {
+			o.fatalStatuses = make(map[int]bool, len(codes))
+		}
+		for _, code := range codes {
+			o.fatalStatuses[code] = true
+		}
+	}
+}
+
+func applyDownloadOptions(opts []DownloadOption) downloadOptions {
+	var o downloadOptions
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&o)
+		}
+	}
+	return o
 }
 
 func (r *progressReader) Read(p []byte) (int, error) {
@@ -150,7 +221,8 @@ func (c *Client) PostForm(ctx context.Context, url string, params map[string]str
 
 // Download 执行大文件流式下载任务。
 // onProgress 会在每次成功读取到响应体字节后回调，用于上层吞吐量统计。
-func (c *Client) Download(ctx context.Context, uri string, target string, headers map[string]string, retry int, timeout int, p *mpb.Progress, name string, originalName string, onProgress func(int64)) (res map[string]interface{}, err error) {
+func (c *Client) Download(ctx context.Context, uri string, target string, headers map[string]string, retry int, timeout int, p *mpb.Progress, name string, originalName string, onProgress func(int64), opts ...DownloadOption) (res map[string]interface{}, err error) {
+	dopts := applyDownloadOptions(opts)
 	targetDir := filepath.Dir(target)
 	if !util.IsDir(targetDir) {
 		if mkdirErr := os.MkdirAll(targetDir, os.ModePerm); mkdirErr != nil {
@@ -172,6 +244,14 @@ func (c *Client) Download(ctx context.Context, uri string, target string, header
 
 		metaPath := resumeMetadataPath(currentTarget)
 		meta, _ := loadResumeMetadata(metaPath)
+
+		// 换源下载时本地残留的是另一条 URL 的半成品，不能接着 Range，否则会把两种码流拼在一起。
+		if startBytes > 0 && (meta == nil || meta.URI != uri) {
+			_ = os.Remove(currentTarget)
+			_ = removeResumeMetadata(metaPath)
+			startBytes = 0
+			meta = nil
+		}
 
 		req := c.resty.R().
 			SetContext(context.WithoutCancel(ctx)).
@@ -219,7 +299,10 @@ func (c *Client) Download(ctx context.Context, uri string, target string, header
 
 		if statusCode != http.StatusOK && statusCode != http.StatusPartialContent {
 			rawBody.Close()
-			err = fmt.Errorf("download failed with status: %s", resp.Status())
+			err = &StatusError{Code: statusCode, Status: resp.Status()}
+			if dopts.fatalStatuses[statusCode] {
+				return nil, err
+			}
 			if attempt < maxAttempts-1 {
 				isRiskControl := statusCode == http.StatusForbidden || statusCode == http.StatusTooManyRequests || statusCode == http.StatusServiceUnavailable
 				if waitErr := c.waitRetry(ctx, p, attempt, currentName, isRiskControl); waitErr != nil {

--- a/internal/qzone/client.go
+++ b/internal/qzone/client.go
@@ -312,68 +312,6 @@ func (c *Client) GetPhotoList(ctx context.Context, targetUin string, albumID str
 	return allPhotos, nil
 }
 
-// GetVideoDownloadURL 获取指定视频或实况图的真实下载直链
-// 对于 MP4 视频或实况图，QQ 空间需要通过该专用接口获取带有 token 的真实下载地址
-func (c *Client) GetVideoDownloadURL(ctx context.Context, targetUin string, albumID string, sloc string) (string, error) {
-	headers := map[string]string{
-		"cookie":     c.Cookie,
-		"user-agent": UserAgent,
-		"referer":    fmt.Sprintf("https://user.qzone.qq.com/%s/infocenter", targetUin),
-	}
-
-	apiURL := fmt.Sprintf("https://h5.qzone.qq.com/proxy/domain/photo.qzone.qq.com/fcgi-bin/cgi_floatview_photo_list_v2?g_tk=%v&callback=viewer_Callback&topicId=%v&picKey=%v&cmtOrder=1&fupdate=1&plat=qzone&source=qzone&cmtNum=0&inCharset=utf-8&outCharset=utf-8&callbackFun=viewer&uin=%v&hostUin=%v&appid=4&isFirst=1", c.GTK, albumID, sloc, c.QQ, targetUin)
-
-	start := time.Now()
-	_, body, code, err := c.Http.Get(ctx, apiURL, headers)
-	duration := time.Since(start)
-
-	bodyStr := string(body)
-	c.logAPI("GetVideoDownloadURL", apiURL, headers, bodyStr, code, duration, err)
-
-	if err != nil {
-		return "", err
-	}
-	if code != 200 {
-		return "", fmt.Errorf("failed to fetch video download url: status code %d", code)
-	}
-
-	data, err := parseJSONP(bodyStr, "viewer_Callback")
-	if err != nil {
-		return "", fmt.Errorf("failed to parse video response: %w (raw body: %s)", err, bodyStr)
-	}
-
-	res := gjson.Parse(data)
-	photos := res.Get("data.photos").Array()
-	if len(photos) == 0 {
-		return "", fmt.Errorf("no video found in response")
-	}
-
-	video := photos[res.Get("data.picPosInPage").Int()]
-	vInfo := video.Get("video_info")
-
-	// 优先获取 download_url 或 video_url，只要有链接就尝试下载，忽略 status 限制
-	downloadURL := vInfo.Get("download_url").String()
-	if downloadURL == "" {
-		downloadURL = vInfo.Get("video_url").String()
-	}
-
-	// 如果仍然为空，且状态不为 2，才报错
-	if downloadURL == "" && vInfo.Get("status").Int() != 2 {
-		return "", fmt.Errorf("video is not ready and no URL found (status: %d, video_info: %s)", vInfo.Get("status").Int(), vInfo.Raw)
-	}
-
-	// 尝试获取高清地址，但保留原始地址作为备份
-	finalURL := downloadURL
-	if strings.Contains(downloadURL, ".f20.mp4") {
-		highResURL := strings.Replace(downloadURL, ".f20.mp4", ".f0.mp4", 1)
-		// 检查高清地址是否可用（发送一个 HEAD 请求）
-		// 注意：如果 HEAD 请求太慢或被封，可能需要直接在下载逻辑里做重试
-		finalURL = highResURL
-	}
-
-	return finalURL, nil
-}
-
 // GetFriendList 获取当前用户的所有好友列表
 // 并并发检测每个好友的空间访问权限 (是否对我开放)
 func (c *Client) GetFriendList(ctx context.Context) ([]gjson.Result, error) {

--- a/internal/qzone/video.go
+++ b/internal/qzone/video.go
@@ -1,0 +1,341 @@
+/*
+ * Copyright (c) 2026 qinjintian. All rights reserved.
+ *
+ * No Part of this file may be reproduced, stored
+ * in a retrieval system, or transmitted, in any form, or by any means,
+ * electronic, mechanical, photocopying, recording, or otherwise,
+ * without the prior consent of qinjintian.
+ *
+ * @Author: qinjintian<514092640@qq.com>
+ * @Date: 2026-09-01
+ * @LastEditors: qinjintian<514092640@qq.com>
+ * @LastEditTime: 2026-09-01 15:40:00
+ * @FileName: video.go
+ * @Description: [QQ 空间视频多源解析：下载链优先，播放链/HLS/腾讯视频 getinfo 作为失效 URL 的兜底]
+ */
+
+package qzone
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/qinjintian/qq-zone/internal/net/http"
+	"github.com/tidwall/gjson"
+)
+
+const (
+	// VideoSourceDownload 相册原文件下载地址，对应网页端「下载视频」。
+	VideoSourceDownload = "download"
+	// VideoSourcePlay 网页播放器使用的媒体地址，对应 Chrono 一类嗅探器抓到的链接。
+	VideoSourcePlay = "play"
+	// VideoSourceHLS 播放器走 HLS 时的 m3u8 地址。
+	VideoSourceHLS = "hls"
+	// VideoSourceGetInfo 通过 vid 调用腾讯视频 getinfo 解析出的 CDN 地址。
+	VideoSourceGetInfo = "getinfo"
+)
+
+var tencentVIDPattern = regexp.MustCompile(`(?i)^[a-z0-9]{11}$`)
+
+// VideoCandidate 表示一条可尝试的视频拉取地址。
+type VideoCandidate struct {
+	URL  string
+	Kind string
+}
+
+// VideoSource 一次 floatview 解析得到的全部候选源。
+type VideoSource struct {
+	Candidates []VideoCandidate
+	VideoID    string
+}
+
+// GetVideoSource 解析指定相册视频的全部可用地址。
+// 顺序为：download_url（含 f0/f20 清晰度变体）→ video_url 播放链 → HLS。
+// 腾讯视频 getinfo 不会在这里预取，避免每个视频都多打一次接口。
+func (c *Client) GetVideoSource(ctx context.Context, targetUin, albumID, sloc string, photo gjson.Result) (*VideoSource, error) {
+	src := &VideoSource{}
+	var lastErr error
+
+	floatview, err := c.fetchFloatviewVideoInfo(ctx, targetUin, albumID, sloc)
+	if err != nil {
+		lastErr = err
+	} else {
+		src.mergeVideoInfo(floatview)
+	}
+
+	if photo.Exists() {
+		src.mergeVideoInfo(photo.Get("video_info"))
+		if src.VideoID == "" {
+			src.VideoID = firstNonEmpty(photo.Get("video_id").String(), photo.Get("vid").String())
+		}
+	}
+
+	if len(src.Candidates) == 0 {
+		if lastErr != nil {
+			return nil, lastErr
+		}
+		return nil, fmt.Errorf("no video found in response")
+	}
+	return src, nil
+}
+
+// ResolveTencentVideo 在下载链和播放链都失败后，尝试用 vid 换真实 CDN。
+func (c *Client) ResolveTencentVideo(ctx context.Context, vid string) []VideoCandidate {
+	vid = strings.TrimSpace(vid)
+	if vid == "" || !tencentVIDPattern.MatchString(vid) {
+		return nil
+	}
+
+	apis := []string{
+		fmt.Sprintf("https://h5vv.video.qq.com/getinfo?vid=%s&platform=11001&sdtfrom=v1010&otype=json&defn=mp4", vid),
+		fmt.Sprintf("https://vv.video.qq.com/getinfo?vids=%s&platform=101001&charge=0&otype=json&defn=shd", vid),
+	}
+
+	var out []VideoCandidate
+	seen := map[string]bool{}
+	headers := map[string]string{
+		"user-agent": UserAgent,
+		"referer":    "https://v.qq.com/",
+	}
+
+	for _, apiURL := range apis {
+		start := time.Now()
+		_, body, code, err := c.Http.Get(ctx, apiURL, headers)
+		c.logAPI("ResolveTencentVideo", apiURL, headers, string(body), code, time.Since(start), err)
+		if err != nil || code != 200 {
+			continue
+		}
+		for _, u := range parseTencentGetInfoURLs(string(body)) {
+			addVideoCandidate(&out, seen, u, VideoSourceGetInfo)
+		}
+		if len(out) > 0 {
+			break
+		}
+	}
+	return out
+}
+
+func (c *Client) fetchFloatviewVideoInfo(ctx context.Context, targetUin, albumID, sloc string) (gjson.Result, error) {
+	headers := map[string]string{
+		"cookie":     c.Cookie,
+		"user-agent": UserAgent,
+		"referer":    fmt.Sprintf("https://user.qzone.qq.com/%s/infocenter", targetUin),
+	}
+
+	apiURL := fmt.Sprintf("https://h5.qzone.qq.com/proxy/domain/photo.qzone.qq.com/fcgi-bin/cgi_floatview_photo_list_v2?g_tk=%v&callback=viewer_Callback&topicId=%v&picKey=%v&cmtOrder=1&fupdate=1&plat=qzone&source=qzone&cmtNum=0&inCharset=utf-8&outCharset=utf-8&callbackFun=viewer&uin=%v&hostUin=%v&appid=4&isFirst=1", c.GTK, albumID, sloc, c.QQ, targetUin)
+
+	start := time.Now()
+	_, body, code, err := c.Http.Get(ctx, apiURL, headers)
+	duration := time.Since(start)
+	bodyStr := string(body)
+	c.logAPI("GetVideoDownloadURL", apiURL, headers, bodyStr, code, duration, err)
+
+	if err != nil {
+		return gjson.Result{}, err
+	}
+	if code != 200 {
+		return gjson.Result{}, fmt.Errorf("failed to fetch video download url: status code %d", code)
+	}
+
+	data, err := parseJSONP(bodyStr, "viewer_Callback")
+	if err != nil {
+		return gjson.Result{}, fmt.Errorf("failed to parse video response: %w (raw body: %s)", err, bodyStr)
+	}
+
+	res := gjson.Parse(data)
+	photos := res.Get("data.photos").Array()
+	if len(photos) == 0 {
+		return gjson.Result{}, fmt.Errorf("no video found in response")
+	}
+
+	video := pickFloatviewPhoto(photos, sloc, res.Get("data.picPosInPage").Int())
+	vInfo := video.Get("video_info")
+	if !vInfo.Exists() || vInfo.Raw == "" || vInfo.Raw == "{}" {
+		return gjson.Result{}, fmt.Errorf("no video found in response")
+	}
+	return vInfo, nil
+}
+
+func pickFloatviewPhoto(photos []gjson.Result, sloc string, picPos int64) gjson.Result {
+	for _, p := range photos {
+		if p.Get("sloc").String() == sloc || p.Get("lloc").String() == sloc || p.Get("picKey").String() == sloc {
+			return p
+		}
+	}
+	if picPos >= 0 && int(picPos) < len(photos) {
+		return photos[picPos]
+	}
+	for _, p := range photos {
+		if p.Get("is_video").Bool() || p.Get("video_info").Exists() {
+			return p
+		}
+	}
+	return photos[0]
+}
+
+func (src *VideoSource) mergeVideoInfo(vInfo gjson.Result) {
+	if src == nil || !vInfo.Exists() {
+		return
+	}
+
+	if src.VideoID == "" {
+		src.VideoID = firstNonEmpty(vInfo.Get("video_id").String(), vInfo.Get("vid").String())
+	}
+
+	seen := make(map[string]bool, len(src.Candidates)+8)
+	for _, c := range src.Candidates {
+		seen[c.URL] = true
+	}
+
+	var downloadURLs, playURLs []string
+	for _, key := range []string{"download_url", "downloadUrl", "origin_url"} {
+		if u := vInfo.Get(key).String(); u != "" {
+			downloadURLs = append(downloadURLs, u)
+		}
+	}
+	for _, key := range []string{"video_url", "videoUrl", "play_url", "playurl", "url"} {
+		if u := vInfo.Get(key).String(); u != "" {
+			playURLs = append(playURLs, u)
+		}
+	}
+
+	vInfo.ForEach(func(key, value gjson.Result) bool {
+		if value.Type != gjson.String {
+			return true
+		}
+		u := value.String()
+		if !strings.HasPrefix(u, "http") {
+			return true
+		}
+		k := strings.ToLower(key.String())
+		if strings.Contains(k, "cover") || strings.Contains(k, "thumb") || strings.Contains(k, "pic") || strings.Contains(k, "image") {
+			return true
+		}
+		if strings.Contains(k, "download") {
+			downloadURLs = append(downloadURLs, u)
+			return true
+		}
+		if strings.Contains(k, "video") || strings.Contains(k, "play") || k == "url" {
+			playURLs = append(playURLs, u)
+		}
+		return true
+	})
+
+	appendVariants := func(raw string, kind string) {
+		for _, u := range qualityVariants(raw) {
+			if http.IsHLSURL(u) {
+				addVideoCandidate(&src.Candidates, seen, u, VideoSourceHLS)
+				continue
+			}
+			addVideoCandidate(&src.Candidates, seen, u, kind)
+		}
+	}
+
+	for _, u := range downloadURLs {
+		appendVariants(u, VideoSourceDownload)
+	}
+	for _, u := range playURLs {
+		appendVariants(u, VideoSourcePlay)
+	}
+}
+
+func addVideoCandidate(dst *[]VideoCandidate, seen map[string]bool, raw, kind string) {
+	for _, u := range expandURLSchemes(raw) {
+		if u == "" || seen[u] {
+			continue
+		}
+		seen[u] = true
+		*dst = append(*dst, VideoCandidate{URL: u, Kind: kind})
+	}
+}
+
+func qualityVariants(raw string) []string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+	out := make([]string, 0, 3)
+	push := func(u string) {
+		if u == "" {
+			return
+		}
+		for _, exist := range out {
+			if exist == u {
+				return
+			}
+		}
+		out = append(out, u)
+	}
+	switch {
+	case strings.Contains(raw, ".f20.mp4"):
+		push(strings.Replace(raw, ".f20.mp4", ".f0.mp4", 1))
+		push(raw)
+	case strings.Contains(raw, ".f0.mp4"):
+		push(raw)
+		push(strings.Replace(raw, ".f0.mp4", ".f20.mp4", 1))
+	default:
+		push(raw)
+	}
+	return out
+}
+
+func expandURLSchemes(raw string) []string {
+	raw = strings.TrimSpace(strings.ReplaceAll(raw, `\/`, "/"))
+	if raw == "" || !strings.HasPrefix(raw, "http") {
+		return nil
+	}
+	out := []string{raw}
+	if strings.HasPrefix(raw, "http://") {
+		out = append(out, "https://"+strings.TrimPrefix(raw, "http://"))
+	}
+	return out
+}
+
+func parseTencentGetInfoURLs(body string) []string {
+	jsonStr := strings.TrimSpace(body)
+	if i := strings.Index(jsonStr, "{"); i >= 0 {
+		if j := strings.LastIndex(jsonStr, "}"); j > i {
+			jsonStr = jsonStr[i : j+1]
+		}
+	}
+	res := gjson.Parse(jsonStr)
+	vi := res.Get("vl.vi.0")
+	if !vi.Exists() {
+		return nil
+	}
+	fn := vi.Get("fn").String()
+	fvkey := vi.Get("fvkey").String()
+	if fn == "" || fvkey == "" {
+		return nil
+	}
+	// 分片视频结构更复杂，这里只兜底完整 mp4。
+	if vi.Get("cl.fc").Int() > 0 {
+		return nil
+	}
+
+	var urls []string
+	vi.Get("ul.ui").ForEach(func(_, ui gjson.Result) bool {
+		base := strings.TrimSpace(ui.Get("url").String())
+		if base == "" {
+			return true
+		}
+		if !strings.HasSuffix(base, "/") {
+			base += "/"
+		}
+		urls = append(urls, base+fn+"?vkey="+fvkey)
+		return true
+	})
+	return urls
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
🚀 fix: 视频下载链 403 时回退到播放 URL 兜底下载

QQ 空间网页能播但无法下载的视频，download_url 往往已经失效。
遇到 403/404 时不再当作风控重试死链，改为依次尝试播放 URL、HLS 和 vid 解析。