### PR TITLE
fix: 留言板增量刷新回复并显示楼层，说说全屏视频保持原比例

### DIFF
--- a/internal/app/board_backup.go
+++ b/internal/app/board_backup.go
@@ -54,7 +54,7 @@ func NewBoardBackup(client *qzone.Client, config *Config, logger *zap.SugaredLog
 }
 
 // Backup 拉取 targetUin 的留言、下载配图并生成 index.html。
-// exclude=true 时从最新往回拉，连续碰到已备份的留言 id 就停。
+// exclude=true 时从最新往回拉；已有留言仍会收下以刷新回复，整页都是本地已有 id 才停。
 func (b *BoardBackup) Backup(ctx context.Context, targetUin string, exclude bool) (*DownloadResult, error) {
 	b.results = DownloadResult{}
 	root := boardRoot(targetUin)
@@ -153,8 +153,10 @@ func (b *BoardBackup) Backup(ctx context.Context, targetUin string, exclude bool
 
 	// 完全无权时不要再打好友备注和配图接口，免得雪上加霜。
 	if !blocked {
-		// 接口只给昵称；查看页要和空间网页一样显示好友备注。
-		b.applyFriendRemarks(ctx, p, posts)
+		// 接口只给昵称；查看页要和空间网页一样显示好友备注（含留言板主人）。
+		if remark := b.applyFriendRemarks(ctx, p, targetUin, posts); remark != "" {
+			nickname = remark
+		}
 
 		if err := b.downloadAllMedia(ctx, p, root, targetUin, posts); err != nil && ctx.Err() == nil {
 			b.logger.Warnf("配图下载过程出现中断: %v", err)
@@ -296,8 +298,8 @@ func (b *BoardBackup) RetryFailed(ctx context.Context, targetUin string, items [
 	return &b.results, nil
 }
 
-// fetchMessages 分页拉留言。增量模式下连续碰到 3 条本地已有 id 就停，
-// 避免把整本历史再翻一遍；start 必须按 20 递增，接口不会按实际返回条数对齐。
+// fetchMessages 分页拉留言。增量时本页 id 本地都有就停（本页仍会收下，用来覆盖新回复）；
+// start 必须按 20 递增，接口不会按实际返回条数对齐。
 func (b *BoardBackup) fetchMessages(ctx context.Context, p *mpb.Progress, targetUin string, exclude bool, known map[string]MoodPost) ([]MoodPost, error) {
 	wait := waitSpinner(p, "正在请求留言板")
 	first, err := b.client.GetMsgBoard(ctx, targetUin, 0)
@@ -308,6 +310,7 @@ func (b *BoardBackup) fetchMessages(ctx context.Context, p *mpb.Progress, target
 		}
 		return nil, err
 	}
+	b.spaceUin = targetUin
 
 	if len(first.Items) == 0 && first.Total <= 0 {
 		b.logger.Infof("空间 [%s] 没有可见的留言", targetUin)
@@ -333,7 +336,6 @@ func (b *BoardBackup) fetchMessages(ctx context.Context, p *mpb.Progress, target
 		posts     []MoodPost
 		start     = 0
 		emptyHits = 0
-		knownHits = 0
 		page      = first
 		pageIdx   = 0
 	)
@@ -372,31 +374,29 @@ func (b *BoardBackup) fetchMessages(ctx context.Context, p *mpb.Progress, target
 		}
 		emptyHits = 0
 
-		stop := false
-		for _, item := range page.Items {
-			msg := parseBoardMessage(item)
+		pageAllKnown := exclude && len(page.Items) > 0
+		for i, item := range page.Items {
+			floor := 0
+			if page.Total > 0 {
+				floor = page.Total - start - i
+			}
+			msg := parseBoardMessage(item, floor)
 			if msg.TID == "" {
 				continue
 			}
 			if exclude {
-				if _, ok := known[msg.TID]; ok {
-					knownHits++
-					if knownHits >= 3 {
-						stop = true
-						break
-					}
-					continue
+				if _, ok := known[msg.TID]; !ok {
+					pageAllKnown = false
 				}
-				knownHits = 0 // 中间又出现新留言，说明还没接到本地已有区间
 			}
+			// 已有留言也收下，这样对方后来补的回复能覆盖进 backup.json / index.html。
 			posts = append(posts, msg)
-			// 总数始终比已保存条数多 1，避免中途 current==total 把条关掉。
 			bar.SetTotal(int64(len(posts))+1, false)
 			bar.Increment()
 		}
 
-		if stop {
-			b.logger.Infof("增量模式：已遇到本地已有留言，停止继续往前翻页")
+		if pageAllKnown {
+			b.logger.Infof("增量模式：本页留言本地都有，已用接口结果覆盖回复后停止往前翻页")
 			break
 		}
 
@@ -435,14 +435,15 @@ func (b *BoardBackup) captureIntro(page *qzone.MsgBoardPage) {
 	b.intro = parseBoardIntro(page.Nickname, uin, page.Sign)
 }
 
-// applyFriendRemarks 用登录账号的好友备注覆盖留言者/回复者昵称，和空间网页一致。
-func (b *BoardBackup) applyFriendRemarks(ctx context.Context, p *mpb.Progress, posts []MoodPost) {
+// applyFriendRemarks 用登录账号的好友备注覆盖留言者/回复者/主人寄语的昵称，和空间网页一致。
+// 返回值是空间主人的展示名（有备注用备注），给查看页标题用。
+func (b *BoardBackup) applyFriendRemarks(ctx context.Context, p *mpb.Progress, targetUin string, posts []MoodPost) string {
 	if b.client == nil {
 		applyFriendNamesToPosts(posts, nil)
-		return
+		return ""
 	}
-	if len(posts) == 0 && (b.intro == nil || b.intro.Author.UIN == "") {
-		return
+	if len(posts) == 0 && (b.intro == nil || b.intro.Author.UIN == "") && targetUin == "" {
+		return ""
 	}
 	wait := waitSpinner(p, "正在拉取好友备注")
 	names, err := b.client.GetFriendDisplayNames(ctx)
@@ -450,14 +451,18 @@ func (b *BoardBackup) applyFriendRemarks(ctx context.Context, p *mpb.Progress, p
 	if err != nil {
 		b.logger.Warnf("拉取好友备注失败，留言仍显示昵称: %v", err)
 		applyFriendNamesToPosts(posts, nil)
-		return
+		return ""
 	}
 	applyFriendNamesToPosts(posts, names)
-	if b.intro != nil && b.intro.Author.UIN != "" {
+	if b.intro != nil {
+		if b.intro.Author.UIN == "" {
+			b.intro.Author.UIN = targetUin
+		}
 		if n := strings.TrimSpace(names[b.intro.Author.UIN]); n != "" {
 			b.intro.Author.Name = n
 		}
 	}
+	return strings.TrimSpace(names[targetUin])
 }
 
 // downloadAllMedia 并发下载留言和回复里的配图；本地已有非空文件会跳过。

--- a/internal/app/board_parse.go
+++ b/internal/app/board_parse.go
@@ -41,12 +41,14 @@ var (
 
 // parseBoardMessage 把 get_msgb 的一条 commentList 收成 MoodPost。
 // tid 用留言 id；回复放进 comments；私密留言只保留占位文案，不暴露正文。
-func parseBoardMessage(item gjson.Result) MoodPost {
+// floor 是本页推算的楼层（总数 - 偏移）；接口没给楼层字段时用它。
+func parseBoardMessage(item gjson.Result, floor int) MoodPost {
 	id := strings.TrimSpace(firstMoodString(item, "id", "msgid", "commentid"))
 	secret := item.Get("secret").Int() != 0 || item.Get("isscret").Int() != 0 || item.Get("isSecret").Bool()
 	created := parseBoardTime(item)
 	post := MoodPost{
 		TID:      id,
+		Floor:    parseBoardFloor(item, id, floor),
 		Time:     created,
 		TimeText: formatMoodTime(created, firstMoodString(item, "pubtime", "pubTime", "time")),
 		Secret:   secret,
@@ -77,14 +79,41 @@ func parseBoardMessage(item gjson.Result) MoodPost {
 	if !replies.Exists() || replies.Type == gjson.Null {
 		replies = item.Get("replylist")
 	}
+	if !replies.Exists() || replies.Type == gjson.Null {
+		replies = item.Get("replys")
+	}
 	if replies.Exists() && replies.Type != gjson.Null {
 		post.Comments = parseBoardReplies(replies.Array())
 	}
 	post.CommentCount = int(item.Get("replyCount").Int())
+	if n := item.Get("replyNum").Int(); int(n) > post.CommentCount {
+		post.CommentCount = int(n)
+	}
 	if post.CommentCount < len(post.Comments) {
 		post.CommentCount = len(post.Comments)
 	}
 	return post
+}
+
+// parseBoardFloor 取出空间页上的「第 N 楼」。
+// 接口偶尔给 floor/index；没有时用调用方按 total-偏移推的值；再没有才从 id 末尾数字猜。
+func parseBoardFloor(item gjson.Result, id string, fallback int) int {
+	for _, key := range []string{"floor", "index", "pos"} {
+		if n := int(item.Get(key).Int()); n > 0 {
+			return n
+		}
+	}
+	if fallback > 0 {
+		return fallback
+	}
+	n, err := strconv.ParseInt(id, 10, 64)
+	if err != nil || n <= 0 {
+		return 0
+	}
+	if r := int(n % 10000); r > 0 {
+		return r
+	}
+	return 0
 }
 
 // parseBoardIntro 取出主人寄语；没有寄语时返回 nil，查看页就不渲染置顶卡片。
@@ -143,13 +172,17 @@ func stripBoardTags(s string) string {
 }
 
 // parseBoardReplies 解析一条留言下的回复列表。
+// 空间 get_msgb 的回复通常只有 content / nick / time，没有 ubbContent 和 id。
 func parseBoardReplies(list []gjson.Result) []MoodComment {
 	if len(list) == 0 {
 		return nil
 	}
 	out := make([]MoodComment, 0, len(list))
 	for _, raw := range list {
-		created := parseBoardTime(raw)
+		created := moodUnixTime(raw, "time", "timestamp", "create_time", "createTime")
+		if created == 0 {
+			created = parseBoardTime(raw)
+		}
 		plain, rich := renderBoardContent(raw)
 		if plain == "" && rich == "" {
 			plain = strings.TrimSpace(firstMoodString(raw, "content", "con", "ubbContent"))
@@ -163,9 +196,12 @@ func parseBoardReplies(list []gjson.Result) []MoodComment {
 			TimeText: formatMoodTime(created, firstMoodString(raw, "pubtime", "time", "createTime")),
 			Author: MoodPerson{
 				UIN:  strings.TrimSpace(firstMoodString(raw, "uin", "fuin")),
-				Name: strings.TrimSpace(firstMoodString(raw, "nickname", "nick", "name", "uinname")),
+				Name: strings.TrimSpace(firstMoodString(raw, "nick", "nickname", "name", "uinname")),
 			},
 			Media: parseBoardMedia(raw, rich),
+		}
+		if c.ID == "" && (c.Author.UIN != "" || created > 0) {
+			c.ID = c.Author.UIN + "-" + strconv.FormatInt(created, 10)
 		}
 		if c.Content == "" && len(c.Media) == 0 && c.Author.Name == "" {
 			continue

--- a/internal/app/board_parse_test.go
+++ b/internal/app/board_parse_test.go
@@ -27,7 +27,7 @@ func TestParseBoardMessageSecret(t *testing.T) {
 		"secret": 1,
 		"pubtime": "2012-05-01 12:00"
 	}`
-	post := parseBoardMessage(gjson.Parse(raw))
+	post := parseBoardMessage(gjson.Parse(raw), 0)
 	if !post.Secret {
 		t.Fatal("want secret")
 	}
@@ -65,7 +65,7 @@ func TestParseBoardMessageImageAndReply(t *testing.T) {
 			}
 		]
 	}`
-	post := parseBoardMessage(gjson.Parse(raw))
+	post := parseBoardMessage(gjson.Parse(raw), 11)
 	if post.TID != "11" || post.Author.Name != "小明" {
 		t.Fatalf("post = %+v", post)
 	}
@@ -80,6 +80,9 @@ func TestParseBoardMessageImageAndReply(t *testing.T) {
 	}
 	if len(post.Media) != 1 || !strings.Contains(post.Media[0].URL, "b.example/pic.jpg") {
 		t.Fatalf("media = %+v", post.Media)
+	}
+	if post.Floor != 11 {
+		t.Fatalf("floor = %d", post.Floor)
 	}
 	if len(post.Comments) != 1 || post.Comments[0].Content != "收到" {
 		t.Fatalf("comments = %+v", post.Comments)
@@ -96,7 +99,10 @@ func TestParseBoardMessageEmoteNotMedia(t *testing.T) {
 		"ubbContent": "就像今天。[em]e182[/em]",
 		"pubtime": "2026-09-08 13:00:23"
 	}`
-	post := parseBoardMessage(gjson.Parse(raw))
+	post := parseBoardMessage(gjson.Parse(raw), 0)
+	if post.Floor != 11 {
+		t.Fatalf("floor from id = %d", post.Floor)
+	}
 	if len(post.Media) != 0 {
 		t.Fatalf("bmp/emote should not be media: %+v", post.Media)
 	}
@@ -148,12 +154,20 @@ func TestWriteBoardViewer(t *testing.T) {
 		},
 		Posts: []MoodPost{{
 			TID:      "11",
+			Floor:    11,
 			Time:     1520855040,
 			TimeText: "2018-03-12 21:04",
 			Content:  "你好",
 			HTML:     `你好<img src="/qzone/em/e182.gif" />`,
 			Secret:   true,
 			Author:   MoodPerson{UIN: "20001", Name: "好友"},
+			Comments: []MoodComment{{
+				ID:       "r1",
+				Content:  "收到",
+				HTML:     "收到",
+				TimeText: "2018-03-12 22:00",
+				Author:   MoodPerson{UIN: "10001", Name: "小明"},
+			}},
 			Media: []MoodMedia{{
 				Type: "image",
 				Path: "media/2018/03/a.jpg",
@@ -181,6 +195,12 @@ func TestWriteBoardViewer(t *testing.T) {
 	}
 	if !strings.Contains(string(js), "qzonestyle.gtimg.cn/qzone/em/e182.gif") {
 		t.Fatal("viewer js should rewrite relative emote to official CDN")
+	}
+	if !strings.Contains(string(js), `"floor":11`) {
+		t.Fatal("viewer js missing floor")
+	}
+	if !strings.Contains(string(js), "收到") {
+		t.Fatal("viewer js missing reply")
 	}
 	meta, err := os.ReadFile(filepath.Join(root, "data", "meta.js"))
 	if err != nil {
@@ -216,5 +236,126 @@ func TestIsBoardTask(t *testing.T) {
 	}
 	if IsBoardTask(&TaskRecord{Mode: TaskModeShuoShuo}) {
 		t.Fatal("shuoshuo should not match")
+	}
+}
+
+func TestParseBoardMessageAPIReplyAndFloorFallback(t *testing.T) {
+	raw := `{
+		"id": "1000050011",
+		"uin": 10002,
+		"nickname": "张三",
+		"htmlContent": "今天天气不错",
+		"pubtime": "2026-09-08 13:00:23",
+		"replyList": [{
+			"content": "@{uin:10002,nick:张三} 收到了",
+			"uin": 10001,
+			"time": 1788871055,
+			"nick": "李四"
+		}]
+	}`
+	post := parseBoardMessage(gjson.Parse(raw), 11)
+	if post.Floor != 11 {
+		t.Fatalf("floor = %d", post.Floor)
+	}
+	if len(post.Comments) != 1 {
+		t.Fatalf("comments = %+v", post.Comments)
+	}
+	c := post.Comments[0]
+	if c.Author.UIN != "10001" || c.Author.Name != "李四" {
+		t.Fatalf("reply author = %+v", c.Author)
+	}
+	if !strings.Contains(c.Content, "收到了") {
+		t.Fatalf("reply content = %q", c.Content)
+	}
+	if strings.Contains(c.HTML, "@{uin:") {
+		t.Fatalf("raw at-uin still in html: %s", c.HTML)
+	}
+	if c.Time != 1788871055 {
+		t.Fatalf("reply time = %d", c.Time)
+	}
+	if want := formatMoodTime(1788871055, ""); c.TimeText != want {
+		t.Fatalf("reply time_text = %q want %q", c.TimeText, want)
+	}
+
+	posts := []MoodPost{post}
+	applyFriendNamesToPosts(posts, map[string]string{
+		"10001": "王五",
+		"10002": "老张",
+	})
+	if posts[0].Author.Name != "老张" {
+		t.Fatalf("board owner remark = %q", posts[0].Author.Name)
+	}
+	if posts[0].Comments[0].Author.Name != "王五" {
+		t.Fatalf("reply remark = %q", posts[0].Comments[0].Author.Name)
+	}
+	if !strings.Contains(posts[0].Comments[0].HTML, "老张") {
+		t.Fatalf("at-mention should use remark: %s", posts[0].Comments[0].HTML)
+	}
+}
+
+func TestParseBoardFloorPrefersExplicitThenFallback(t *testing.T) {
+	item := gjson.Parse(`{"id":"1000050003","floor":7}`)
+	if n := parseBoardFloor(item, "1000050003", 11); n != 7 {
+		t.Fatalf("explicit floor = %d", n)
+	}
+	item = gjson.Parse(`{"id":"abc"}`)
+	if n := parseBoardFloor(item, "abc", 4); n != 4 {
+		t.Fatalf("fallback floor = %d", n)
+	}
+}
+
+func TestMergeMoodPostsKeepsNewerReplies(t *testing.T) {
+	older := []MoodPost{{
+		TID:     "11",
+		Time:    100,
+		Content: "旧正文",
+		Media:   []MoodMedia{{ID: "pic1", Type: "image", Path: "media/a.jpg", URL: "https://example/a.jpg"}},
+	}}
+	newer := []MoodPost{{
+		TID:     "11",
+		Time:    100,
+		Floor:   11,
+		Content: "旧正文",
+		Media:   []MoodMedia{{ID: "pic1", Type: "image", URL: "https://example/a.jpg"}},
+		Comments: []MoodComment{{
+			ID:      "10001-1788871055",
+			Content: "新回复",
+			Author:  MoodPerson{UIN: "10001", Name: "王五"},
+		}},
+	}}
+	merged := mergeMoodPosts(newer, older)
+	if len(merged) != 1 {
+		t.Fatalf("len = %d", len(merged))
+	}
+	got := keepBoardMedia(merged[0], older[0])
+	if got.Floor != 11 {
+		t.Fatalf("floor = %d", got.Floor)
+	}
+	if len(got.Comments) != 1 || got.Comments[0].Content != "新回复" {
+		t.Fatalf("comments = %+v", got.Comments)
+	}
+	if got.Media[0].Path != "media/a.jpg" {
+		t.Fatalf("local media path lost: %+v", got.Media)
+	}
+}
+
+func TestBoardViewerAssetsShowFloorAndReplies(t *testing.T) {
+	js, err := os.ReadFile(filepath.Join("viewer", "assets", "viewer.js"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(js)
+	if !strings.Contains(body, "第") || !strings.Contains(body, "p.floor") {
+		t.Fatal("viewer.js should render 第N楼")
+	}
+	if !strings.Contains(body, "isBoard ? comments") {
+		t.Fatal("viewer.js should expand all board replies")
+	}
+	css, err := os.ReadFile(filepath.Join("viewer", "assets", "viewer.css"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(css), ".floor") {
+		t.Fatal("viewer.css missing .floor")
 	}
 }

--- a/internal/app/mood.go
+++ b/internal/app/mood.go
@@ -89,8 +89,9 @@ type MoodPost struct {
 	Likes        []MoodPerson  `json:"likes,omitempty"`          // 点赞人名单，来自 get_like_list_app 的 like_uin_info
 	LikeCount    int           `json:"like_count"`               // 点赞人数，来自 qz_opcnt2 likedata.cnt 或点赞名单总数
 	VisitCount   int           `json:"visit_count,omitempty"`    // 浏览次数，来自 qz_opcnt2 current.newdata（如 PRD）
-	Comments     []MoodComment `json:"comments,omitempty"`       // 评论（含楼中楼）
+	Comments     []MoodComment `json:"comments,omitempty"`       // 评论（含楼中楼）；留言板里是这条留言下的回复
 	CommentCount int           `json:"comment_count"`            // 空间侧声明的评论数
+	Floor        int           `json:"floor,omitempty"`          // 留言板楼层，空间页「第N楼」；说说不用
 	Secret       bool          `json:"secret,omitempty"`         // 留言板私密留言；当前账号看不到正文
 	HasMoreCon   bool          `json:"-"`                        // 列表里正文被截断，需要再拉详情
 	PicTotal     int           `json:"-"`                        // 空间侧声明的配图总数，用来判断要不要补拉
@@ -179,7 +180,8 @@ func sortMoodPosts(posts []MoodPost) {
 	})
 }
 
-// mergeMoodPosts 把本轮新拉到的说说和本地已有记录按 tid 合并；相同 tid 保留 newer。
+// mergeMoodPosts 把本轮新拉到的记录和本地已有记录按 tid 合并；相同 tid 保留 newer。
+// 留言板增量会重新收下已有 id（用来覆盖新回复），必须让 newer 赢，不能被本地旧条目盖回去。
 func mergeMoodPosts(newer, older []MoodPost) []MoodPost {
 	seen := make(map[string]int, len(newer)+len(older))
 	out := make([]MoodPost, 0, len(newer)+len(older))
@@ -189,8 +191,7 @@ func mergeMoodPosts(newer, older []MoodPost) []MoodPost {
 				out = append(out, p)
 				continue
 			}
-			if idx, ok := seen[p.TID]; ok {
-				out[idx] = p
+			if _, ok := seen[p.TID]; ok {
 				continue
 			}
 			seen[p.TID] = len(out)

--- a/internal/app/mood_parse_test.go
+++ b/internal/app/mood_parse_test.go
@@ -173,6 +173,17 @@ func TestWriteMoodViewer(t *testing.T) {
 	if !strings.Contains(string(html), "posts-2018.js") {
 		t.Fatal("index.html missing year script")
 	}
+	css, err := os.ReadFile(filepath.Join(root, "assets", "viewer.css"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(css)
+	if !strings.Contains(body, "video:fullscreen") || !strings.Contains(body, "video:-webkit-full-screen") {
+		t.Fatal("viewer css missing fullscreen video rules")
+	}
+	if !strings.Contains(body, "object-fit: contain") {
+		t.Fatal("fullscreen video should keep aspect ratio")
+	}
 }
 
 func TestMoodHiddenFromViewer(t *testing.T) {

--- a/internal/app/viewer/assets/viewer.css
+++ b/internal/app/viewer/assets/viewer.css
@@ -224,6 +224,12 @@ html[data-theme="dark"] .like-name { color: #8ab4f8; }
 }
 .meta { min-width: 0; flex: 1; }
 .name { font-weight: 700; font-size: 15px; }
+.floor {
+  font-weight: 400;
+  font-size: 12px;
+  color: var(--muted);
+  margin-left: 8px;
+}
 .when {
   margin-top: 3px;
   color: var(--muted);
@@ -278,6 +284,25 @@ html[data-theme="dark"] .like-name { color: #8ab4f8; }
 }
 .grid.n1 img, .grid.n1 video { height: auto; max-height: 420px; cursor: zoom-in; }
 .grid video { cursor: pointer; background: #000; }
+/* 卡片里用 cover 裁成方格；点控件全屏后必须 contain，否则竖屏视频会被裁掉。两条规则不能写在一起，旧 WebKit 会整段丢掉。 */
+.grid video:fullscreen {
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  max-height: none;
+  object-fit: contain;
+  border-radius: 0;
+  background: #000;
+}
+.grid video:-webkit-full-screen {
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  max-height: none;
+  object-fit: contain;
+  border-radius: 0;
+  background: #000;
+}
 
 .repost {
   margin-top: 12px;
@@ -329,6 +354,17 @@ html[data-theme="dark"] .like-name { color: #8ab4f8; }
   margin-top: 10px;
   padding-top: 10px;
   border-top: 1px solid var(--line);
+}
+html[data-kind="board"] .comments {
+  margin-top: 12px;
+  padding: 8px 12px 4px;
+  border-top: 0;
+  background: var(--page);
+  border-radius: 8px;
+}
+html[data-kind="board"] .comment .c-time {
+  display: block;
+  margin: 2px 0 0;
 }
 .comment {
   display: flex;

--- a/internal/app/viewer/assets/viewer.js
+++ b/internal/app/viewer/assets/viewer.js
@@ -65,8 +65,11 @@
   }
 
   function atUinHtml(s) {
-    return String(s == null ? "" : s).replace(/@\{uin:(\d+),nick:(.*?),who:\d+,auto:\d+\}/g, function (_, uin, nick) {
-      return '<span class="reply-to">回复</span> <span class="mention">' + escapeHtml(nick) + "</span>";
+    return String(s == null ? "" : s).replace(/@\{uin:(\d+),nick:([^}]+)\}/g, function (_, uin, nick) {
+      nick = String(nick || "").replace(/,who:\d+/g, "").replace(/,auto:\d+/g, "");
+      var auto = /auto:1/.test(String(_));
+      var tag = '<span class="mention">' + escapeHtml(nick) + "</span>";
+      return auto ? '<span class="reply-to">回复</span> ' + tag : "@" + tag;
     });
   }
 
@@ -191,10 +194,11 @@
     var comments = p.comments || [];
     var commentBlock = "";
     if (comments.length) {
-      var shown = comments.slice(0, 2).map(commentHtml).join("");
-      var rest = comments.length > 2 ? comments.slice(2).map(commentHtml).join("") : "";
-      commentBlock = '<div class="comments">' + shown +
-        (rest ? '<div class="more" hidden>' + rest + '</div><button type="button" class="toggle" data-more>查看全部 ' + comments.length + copy.more + "</button>" : "") +
+      // 留言板回复条数通常不多，全部展开，和空间网页一致；说说仍默认先显示 2 条。
+      var shown = isBoard ? comments : comments.slice(0, 2);
+      var rest = (!isBoard && comments.length > 2) ? comments.slice(2) : [];
+      commentBlock = '<div class="comments">' + shown.map(commentHtml).join("") +
+        (rest.length ? '<div class="more" hidden>' + rest.map(commentHtml).join("") + '</div><button type="button" class="toggle" data-more>查看全部 ' + comments.length + copy.more + "</button>" : "") +
         "</div>";
     }
     var likeBlock = "";
@@ -212,7 +216,7 @@
     var statsParts = [];
     if (p.visit_count) statsParts.push("浏览" + p.visit_count + "次");
     if (likeCount) statsParts.push("赞(" + likeCount + ")");
-    if (p.comment_count) statsParts.push(p.comment_count + copy.stats);
+    if (!isBoard && p.comment_count) statsParts.push(p.comment_count + copy.stats);
     var stats = statsParts.length
       ? '<div class="stats">' + statsParts.map(function (s) { return "<span>" + escapeHtml(s) + "</span>"; }).join("") + "</div>"
       : "";
@@ -233,9 +237,10 @@
         mediaGrid(p.repost.media, pid + "-rt") + "</div>";
     }
     var badge = p.secret ? '<span class="badge-secret">私密</span>' : "";
+    var floor = (isBoard && p.floor) ? '<span class="floor">第' + p.floor + "楼</span>" : "";
     return '<article class="card" data-id="' + escapeHtml(p.tid || pid) + '">' +
       '<div class="card-head">' + avatarHtml(p.author, "avatar") +
-      '<div class="meta"><div class="name">' + escapeHtml((p.author && p.author.name) || "") + badge + "</div>" +
+      '<div class="meta"><div class="name">' + escapeHtml((p.author && p.author.name) || "") + badge + floor + "</div>" +
       '<div class="when">' + when + loc + src + "</div></div></div>" +
       '<div class="content">' + richText(p.html, p.content) + "</div>" +
       share + mediaGrid(p.media, pid) + repost + stats + likeBlock +
@@ -262,6 +267,7 @@
   }
 
   function fillHeader() {
+    if (isBoard) document.documentElement.setAttribute("data-kind", "board");
     var name = meta.nickname || (isBoard ? "QQ 空间留言" : "QQ 空间说说");
     document.getElementById("title").textContent = name + copy.title;
     document.title = name + copy.title + "备份";

--- a/internal/cli/board.go
+++ b/internal/cli/board.go
@@ -33,7 +33,7 @@ func (c *CLI) handleBoardBackup(ctx context.Context, targetUin string) {
 
 	var answers struct {
 		TaskLimit            string // auto 或 1-50
-		Exclude              bool   // true=增量，碰到已有留言 id 就停
+		Exclude              bool   // true=增量：已有留言刷新回复，整页都熟才停翻页
 		EnableMetadataExport bool   // 是否把接口原始 JSON 存到 raw/
 		OpenViewer           bool   // 备份结束后是否打开 index.html
 	}
@@ -54,7 +54,7 @@ func (c *CLI) handleBoardBackup(ctx context.Context, targetUin string) {
 		{
 			Name: "Exclude",
 			Prompt: &survey.Confirm{
-				Message: "📦 开启增量备份 (跳过已有留言和已下载的配图)?",
+				Message: "📦 开启增量备份 (已有留言会刷新回复，已下载的配图会跳过)?",
 				Default: true,
 			},
 		},


### PR DESCRIPTION
增量再下时会覆盖已有留言的回复；查看页补上第 N 楼、回复列表和好友备注。说说竖屏视频全屏不再被裁切